### PR TITLE
rough draft for a dust-tracking DsrManager

### DIFF
--- a/src/DustTrackingDsrManager.sol
+++ b/src/DustTrackingDsrManager.sol
@@ -103,7 +103,7 @@ contract DustTrackingDsrManager {
         // based on equality: (pie'*chi + dust') - (pie*chi + dust) = wad*RAY
         // where values with a "'" are post-update
         uint256 newPie = add(bal.pie, pie);
-        bal.dust = sub(add(add(mul(wad, RAY), mul(bal.pie, chi)), bal.dust), newPie);
+        bal.dust = sub(add(add(mul(wad, RAY), mul(bal.pie, chi)), bal.dust), mul(newPie, chi));
         bal.pie = newPie;
 
         emit Join(src, wad);


### PR DESCRIPTION
DRAFT
Here's a rough draft (untested) of an alternative implementation.

Big changes:
1. Dust is tracked, and does not become permanently "stuck" unless someone loses their keys.
2. `join` takes a `src` address to pull DAI from--this not is more symmetrical, but should prevent accidents in which a contract user unintentionally `joins` DAI into an address they don't control

Little changes:
 - I got rid of `supply`, it wasn't accomplishing anything--I'm not opposed to adding it back if there's some good reason to have it
 - I added a `joinAll` method for ergonomic purposes

I used SafeMath everywhere, though there are a lot of places we could optimize to unchecked operations due to success of prior operations implying safety of later operations.

Intended invariants of the contract (we should check these w/formal methods if we go with this option):
A) After `joining` a `wad` of DAI, a sender can always withdraw at least `wad` of DAI on the first subsequent (`exit`|`exitAll`) call.
B) `Pot.pie(DsrManager)` and `Vat.dai(DsrManager)` can always be brought to exactly zero simultaneously via public method calls to the DsrManager by a finite set of addresses.

More invariants probably can and should be defined (e.g. to express ownership properties and dai recoverability under interest accrual more completely).